### PR TITLE
[Discussion] New typing for Middleware concept

### DIFF
--- a/example/index2.ml
+++ b/example/index2.ml
@@ -15,7 +15,7 @@ module Birds = struct
         |> Js.Date.toString
       in 
       Js.log ("Time: " ^ date);
-      next () [@bs]
+      next Js.undefined [@bs]
     ); 
 
     Router.get router "/" @@ Middleware.ofF (fun _ res _ -> 
@@ -38,7 +38,7 @@ let () =
   (* Show how to add a Middleware from a function *)
   App.use app @@ Middleware.ofF (fun _ _ next -> 
     Js.log "Request received";
-    next () [@bs]
+    next Js.undefined [@bs]
   ); 
 
   (* -- *)
@@ -59,7 +59,7 @@ let () =
     Middleware.ofF (fun req _ next-> 
       Js.log @@ Request.params req; 
       print_endline "Just got who";
-      next () [@bs];
+      next Js.undefined [@bs];
     );
 
     Middleware.ofF (fun _ res _ -> 
@@ -71,7 +71,7 @@ let () =
   App.getN app "/from/:who" fromMiddlewares;
   
   App.get app "/skip" @@ Middleware.ofF (fun _ _ next -> 
-    Next.to_router next [@bs]
+    next (Js.Undefined.return "router") [@bs]
   );
 
   (* -- *)

--- a/example/index2.ml
+++ b/example/index2.ml
@@ -69,6 +69,10 @@ let () =
   |] in 
   
   App.getN app "/from/:who" fromMiddlewares;
+  
+  App.get app "/skip" @@ Middleware.ofF (fun _ _ next -> 
+    Next.to_router next [@bs]
+  );
 
   (* -- *)
 

--- a/example/index2.ml
+++ b/example/index2.ml
@@ -1,0 +1,91 @@
+open Express2 
+
+(* This is the exact same example from the Express documentation 
+ * on how to create a Router *) 
+module Birds = struct 
+
+  let router = Router.make () 
+
+  let () =
+    Router.use router @@ Middleware.ofF (fun _ _ next -> 
+
+      let date = 
+        Js.Date.now () 
+        |> Js.Date.fromFloat
+        |> Js.Date.toString
+      in 
+      Js.log ("Time: " ^ date);
+      next () [@bs]
+    ); 
+
+    Router.get router "/" @@ Middleware.ofF (fun _ res _ -> 
+      Response.sendString res "Birds Home Page"
+    ); 
+
+    Router.get router "/about" @@ Middleware.ofF (fun _ res _ -> 
+      Response.sendString res "About birds"
+    )
+end 
+
+let () = 
+  let app = App.express () in 
+
+  (* Show how to add a Middleware made out of a Router class *)
+  App.useOnPath app "/birds" (Birds.router |> Router.toMiddleware); 
+
+  (* -- *)
+
+  (* Show how to add a Middleware from a function *)
+  App.use app @@ Middleware.ofF (fun _ _ next -> 
+    Js.log "Request received";
+    next () [@bs]
+  ); 
+
+  (* -- *)
+
+  (* Show how to add an Error Handling Middleware *)
+  App.use app @@ Middleware.ofErrorF (fun err _ res _ -> 
+    Js.log err; 
+    Response.sendString res "error"
+  ); 
+     
+  (* -- *)
+
+  (* Show how to add multiple chained Middleware made of functions
+   * for a given method and path *)
+
+  let fromMiddlewares = [|
+
+    Middleware.ofF (fun req _ next-> 
+      Js.log @@ Request.params req; 
+      print_endline "Just got who";
+      next () [@bs];
+    );
+
+    Middleware.ofF (fun _ res _ -> 
+      Response.sendString res "Hello World"; 
+    ); 
+
+  |] in 
+  
+  App.getN app "/from/:who" fromMiddlewares;
+
+  (* -- *)
+
+  (* Show how to add a static middleware *)
+
+  App.useOnPath app "/static" (
+    let options = Static.make_options () in 
+    Static.etag options Js.true_; 
+    Static.static "static-html" options |> Static.toMiddleware
+  );  
+  
+  (* -- *)
+
+  (* Show how to add a Third Party middleware *)
+
+  App.use app (BodyParserJSON.make () |> BodyParserJSON.toMiddleware);
+
+  App.listen app 8000;
+
+  ()

--- a/src/express2.ml
+++ b/src/express2.ml
@@ -35,6 +35,20 @@ module Response = struct
   external sendString : t -> string -> done_ = "send" [@@bs.send] 
 end
 
+module Next = struct 
+
+  type t = unit -> done_ [@bs]
+
+  let to_router : t -> done_ [@bs] = fun [@bs] t ->
+    (* This is the only way I could find to be able to write `next("router")` 
+     * as well *)
+    let module Cast = struct 
+      external arg : t -> (string -> done_ [@bs]) = "%identity"
+    end in 
+    (Cast.arg t) "router" [@bs]
+
+end 
+
 module Middleware = struct 
 
   type next  = unit -> done_ [@bs]

--- a/src/express2.ml
+++ b/src/express2.ml
@@ -35,23 +35,9 @@ module Response = struct
   external sendString : t -> string -> done_ = "send" [@@bs.send] 
 end
 
-module Next = struct 
-
-  type t = unit -> done_ [@bs]
-
-  let to_router : t -> done_ [@bs] = fun [@bs] t ->
-    (* This is the only way I could find to be able to write `next("router")` 
-     * as well *)
-    let module Cast = struct 
-      external arg : t -> (string -> done_ [@bs]) = "%identity"
-    end in 
-    (Cast.arg t) "router" [@bs]
-
-end 
-
 module Middleware = struct 
 
-  type next  = unit -> done_ [@bs]
+  type t = string Js.undefined -> done_ [@bs]
 
   type t 
     (** Middleware abstract type which unified the various way an 

--- a/src/express2.ml
+++ b/src/express2.ml
@@ -1,0 +1,172 @@
+type done_
+(** abstract type which ensure middleware function must either
+    call the [next] function or one of the [send] function on the 
+    response object. 
+
+    This should be a great argument for OCaml, the type system 
+    prevents silly error which in this case would make the server hang *)
+
+(** TODO : maybe this should be a more common module like bs-error *)
+module Error = struct 
+
+  type t 
+
+  external message : t -> string option = "" 
+    [@@bs.send] [@@bs.return null_undefined_to_opt]
+  
+  external name : t -> string option = "" 
+    [@@bs.send] [@@bs.return null_undefined_to_opt]
+
+end 
+
+module Request = struct 
+
+  type t 
+
+  type params = Js_json.t Js_dict.t
+
+  external params : t -> params = "" [@@bs.get]
+end 
+
+module Response = struct 
+
+  type t 
+
+  external sendString : t -> string -> done_ = "send" [@@bs.send] 
+end
+
+module Middleware = struct 
+
+  type next  = unit -> done_ [@bs]
+
+  type t 
+    (** Middleware abstract type which unified the various way an 
+        Express middleware can be constructed:
+        {ul
+        {- from a {b function} using the [ofFunction]}  
+        {- from a Router class}
+        {- from an App class}
+        {- from the third party middleware modules}   
+        }
+      
+        For each of the class which implements the middleware interface 
+        is JavaScript, one can use the "%identity" function to cast
+        it to this type [t] *)
+
+  type f = Request.t -> Response.t -> next -> done_
+
+  external ofF : f -> t = "%identity" 
+  (** Create a Middleware from a function *)
+
+  type errorF = Error.t -> Request.t -> Response.t -> next -> done_ 
+
+  external ofErrorF : errorF -> t = "%identity" 
+  (** Create a Middleware from an error function *)
+
+end 
+
+(** Generate the common Middleware binding function for a given 
+    type. This Functor is used for the Router and App classes. *)
+module MakeBindFunctions(T: sig type t end) = struct 
+
+  external use : T.t -> Middleware.t -> unit = "" [@@bs.send]
+  
+  external useOnPath : T.t -> string -> Middleware.t -> unit = "use" [@@bs.send]
+
+  external get :  
+    T.t -> 
+    string -> 
+    Middleware.t -> 
+    unit = "" [@@bs.send] 
+
+  external getN :  
+    T.t -> 
+    string -> 
+    Middleware.t array -> 
+    unit = "get" [@@bs.send] 
+
+  external post :  
+    T.t -> 
+    string -> 
+    Middleware.t -> 
+    unit = "" [@@bs.send] 
+
+  external postN :  
+    T.t -> 
+    string -> 
+    Middleware.t array -> 
+    unit = "post" [@@bs.send] 
+
+  (* Add put/delete/all ... *)
+end 
+
+module App = struct 
+  type app
+
+  include MakeBindFunctions(struct type t = app end)
+  
+  type t = app
+
+  external express : unit -> t = "" [@@bs.module] 
+
+  external toMiddleware : t -> Middleware.t = "%identity"
+  (** [toMiddleware app] casts an App  to a Middleware type *) 
+
+  external listen : t -> int -> unit = "" [@@bs.send]
+
+end 
+
+module Router = struct 
+  
+  type router 
+
+  include MakeBindFunctions(struct type t = router end)
+
+  type t = router
+  
+  external make : unit -> t = "Router" [@@bs.module "express"] 
+
+  external toMiddleware : t -> Middleware.t = "%identity" 
+  (** [toMiddleware router] casts a Router to a Middleware type *)
+
+end 
+
+module Static = struct 
+
+  type options 
+
+  let make_options : unit -> options = fun () ->
+    (Obj.magic (Js_obj.empty ()) : options) 
+
+  external dotfiles : options -> string -> unit = "" [@@bs.set]
+
+  external etag : options -> Js.boolean -> unit = "" [@@bs.set]
+  
+  (* ... add all the other options *) 
+  
+  type t 
+ 
+  external static : string -> options -> t = "" [@@bs.module "express"] 
+
+  external toMiddleware : t -> Middleware.t = "%identity"
+  (** Cast a Static class to a Middleware *)
+
+end 
+
+(** Example of a Third Party Middleware binding.  
+ *
+ *  !!! This should really be in its own module !!!  *)
+
+module BodyParserJSON = struct 
+
+  type t (* JSON Middleware *)
+
+  external make : unit -> t = "json" [@@bs.module "body-parser"]
+
+  external toMiddleware : t -> Middleware.t = "%identity"
+
+  (* One could skip the identity function and have the json function
+   * returns directly a Middleware.t *) 
+
+end 
+


### PR DESCRIPTION
This PR proposes a new typing scheme for the concept of Middleware in ExpressJs.

It adds the following: 
* The abstract `done_` which leverages the OCaml type sytem to enforce that user defined middleware functions must either call a `send*` function or `next`. This prevent the problem of a server hanging
* The abstract Middleware.t which represents all the possible middleware (user function, user function with error, built-int middleware router middleware and server middleware). This example demonstrate how to type all those different middleware 

Finally it also unify the definition of binding function (use/get/post ...) between App class and Router class using a Functor. 

Since it is quite a big change, this PR is for discussion only to see if you like the idea. If agreed, I can make another PR with Reason code.  