### PR TITLE
Adds status and sendStatus

### DIFF
--- a/src/express.re
+++ b/src/express.re
@@ -200,6 +200,9 @@ module Response = {
 
   external redirectCode : t => int => string => done_ = "redirect" [@@bs.send];
   external redirect : t => string => done_ = "redirect" [@@bs.send];
+
+  external status : t => int => t = "status" [@@bs.send];
+  external sendStatus : t => int => done_ = "sendStatus" [@@bs.send];
 };
 
 module Next : {


### PR DESCRIPTION
It exposes [status](http://expressjs.com/en/api.html#res.status) and [sendStatus](http://expressjs.com/en/api.html#res.sendStatus).

I was trying to play with `[@@bs.send.pipe: t]` but I was unable to get it to work as I wanted. Currently,
```ocaml
Response.sendString (Response.status res 400) "Not parsable"
```
produces 
```javascript
return res.status(400).send("Not parsable");
```
Idealy I would like to be able to do something like that
```ocaml
res
  |> Response.status 400
  |> Response.sendString "Not parsable
```

I tried with `external status : int => t = "status" [@@bs.send.pipe: t];` but got some type errors with the `Response.sendString`. Do you have an idea how this could be fixed?

Anyway, even without the pipe support, I think simply exposing `status` and `sendStatus` might be useful.