### PR TITLE
Added express router

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "server",
     "nodejs"
   ],
-  "author": "Ramana Venkata <idlike2dream@gmail.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/reasonml-community/bs-express/issues"

--- a/tests/reference.data
+++ b/tests/reference.data
@@ -137,6 +137,9 @@ status: 500
 -- Can catch Ocaml Exception--
 Elvis has left the building!
 status: 402
+-- Can use express router--
+Created
+status: 201
 -- Accepts--
 {"success":true}
 -- Accepts Charsets--

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -59,6 +59,7 @@ run_test 'Non 200 Http status' 'GET' '/error'
 run_test 'Promise Middleware' 'GET' '/promise'
 run_test 'Failing Promise Middleware' 'GET' '/failing-promise'
 run_test 'Can catch Ocaml Exception' 'GET' '/ocaml-exception'
+run_test 'Can use express router' 'GET' '/testing/testing/123'
 
 run_header_test() {
   print_test_title "$1"


### PR DESCRIPTION
Fixes #33 
Example of usage:
```ocaml
let router = router();

Router.get(router, ~path="/123") @@ Middleware.from((_, _) => Response.sendStatus(Created));

App.useRouterOnPath(app, ~path="/testing/testing", router);
```