### PR TITLE
Return http server

### DIFF
--- a/src/Express.re
+++ b/src/Express.re
@@ -654,6 +654,10 @@ module Router = {
 
 let router = Router.make;
 
+module Http = {
+  type t;
+};
+
 module App = {
   include
     MakeBindFunctions(
@@ -672,7 +676,7 @@ module App = {
   /*** [asMiddleware app] casts an App instance to a Middleware type */
   [@bs.send]
   external listen_ :
-    (t, int, [@bs.uncurry] (Js.Null_undefined.t(Js.Exn.t) => unit)) => unit =
+    (t, int, [@bs.uncurry] (Js.Null_undefined.t(Js.Exn.t) => unit)) => Http.t =
     "listen";
   let listen = (app, ~port=3000, ~onListen=(_) => (), ()) =>
     listen_(app, port, onListen);

--- a/src/Express.re
+++ b/src/Express.re
@@ -654,7 +654,7 @@ module Router = {
 
 let router = Router.make;
 
-module Http = {
+module HttpServer = {
   type t;
 };
 
@@ -676,7 +676,8 @@ module App = {
   /*** [asMiddleware app] casts an App instance to a Middleware type */
   [@bs.send]
   external listen_ :
-    (t, int, [@bs.uncurry] (Js.Null_undefined.t(Js.Exn.t) => unit)) => Http.t =
+    (t, int, [@bs.uncurry] (Js.Null_undefined.t(Js.Exn.t) => unit)) =>
+    HttpServer.t =
     "listen";
   let listen = (app, ~port=3000, ~onListen=(_) => (), ()) =>
     listen_(app, port, onListen);

--- a/src/Express.rei
+++ b/src/Express.rei
@@ -356,6 +356,8 @@ module Router: {
   let asMiddleware: t => Middleware.t;
 };
 
+module HttpServer: {type t;};
+
 let router:
   (~caseSensitive: bool=?, ~mergeParams: bool=?, ~strict: bool=?, unit) =>
   Router.t;
@@ -373,7 +375,7 @@ module App: {
       ~onListen: Js.null_undefined(Js.Exn.t) => unit=?,
       unit
     ) =>
-    unit;
+    HttpServer.t;
 };
 
 

--- a/tests/reference.data
+++ b/tests/reference.data
@@ -202,3 +202,6 @@ status: 200
 This is a test body
 -- Can set response header via setHeader--
 X-Test-Header: Set
+
+-- Can the user user the javascipt http object directly--
+The server has been called 44 times.

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -120,6 +120,13 @@ run_response_header_test() {
 
 run_response_header_test 'Can set response header via setHeader' 'GET' '/response-set-header'
 
+run_http_server_test() {
+  print_test_title "$1"
+  curl -i -X $2  -w "\nstatus: %{http_code}\n" http://localhost:3000$3 2>&1 | grep -Fi X-Test-Header >> $TEST_DATA
+}
+
+run_text_test "Can the user user the javascipt http object directly" "/get-request-count"
+
 # compare test output to reference data
 
 REFERENCE_DATA=reference.data


### PR DESCRIPTION
This change makes it consistent with https://expressjs.com/en/4x/api.html#app.listen . The `listen` function returns a [net.server](https://nodejs.org/api/net.html#net_class_net_server server) object.

This becomes important for applications such as socket.io. The only way to use socket.io with express is something like the below code:

```javascript
const server = app.listen(port, function() {
  console.log('Express server listening on port ' + port)
})

// Socket.io server listens to our app
const io = require('socket.io').listen(server)
```

I have added a simple test to illustrate this. 