### PR TITLE
Set "files" property in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
   "dependencies": {
     "express": "^4.16.3"
   },
+  "files": [
+    "/lib/src/js",
+    "/src",
+    "/bsconfig.json"
+  ],
   "devDependencies": {
     "@glennsl/bs-json": "^3.0.0",
     "body-parser": "^1.18.3",


### PR DESCRIPTION
I have an app that depends on bs-express. If I `npm install` the app, I'm unable to run it because `lib/js/src/Express.js` is missing from the published package. This PR should make it so that the compiled JS is included in the published package. As a side effect, extra files that don't need to be published (readme, tests, etc) will be excluded.