### PR TITLE
fix doc comments in interface file

### DIFF
--- a/src/Express.rei
+++ b/src/Express.rei
@@ -1,7 +1,7 @@
 type complete;
 
 
-/*** abstract type which ensure middleware function must either
+/** abstract type which ensure middleware function must either
      call the [next] function or one of the [send] function on the
      response object.
 
@@ -10,7 +10,7 @@ type complete;
 module Error: {
   type t = exn;
 
-  /*** Error type */
+  /** Error type */
   let message: Js_exn.t => option(string);
   let name: Js_exn.t => option(string);
 };
@@ -19,67 +19,67 @@ module Request: {
   type t;
   type params = Js.Dict.t(Js.Json.t);
 
-  /*** [params request] return the JSON object filled with the
+  /** [params request] return the JSON object filled with the
        request parameters */
   let params: t => params;
 
-  /*** [asJsonObject request] casts a [request] to a JSON object. It is
+  /** [asJsonObject request] casts a [request] to a JSON object. It is
        common in Express application to use the Request object as a
        placeholder to maintain state through the various middleware which
        are executed. */
   let asJsonObject: t => Js.Dict.t(Js.Json.t);
 
-  /*** [baseUrl request] returns the 'baseUrl' property */
+  /** [baseUrl request] returns the 'baseUrl' property */
   let baseUrl: t => string;
 
-  /*** When using the json body-parser middleware and receiving a request with a
+  /** When using the json body-parser middleware and receiving a request with a
        content type of "application/json", this property is a Js.Json.t that
-       contains the body sent by the request. **/
+       contains the body sent by the request. */
   let bodyJSON: t => option(Js.Json.t);
 
-  /*** When using the raw body-parser middleware and receiving a request with a
+  /** When using the raw body-parser middleware and receiving a request with a
        content type of "application/octet-stream", this property is a
-       Node_buffer.t that contains the body sent by the request. **/
+       Node_buffer.t that contains the body sent by the request. */
   let bodyRaw: t => option(Node_buffer.t);
 
-  /*** When using the text body-parser middleware and receiving a request with a
+  /** When using the text body-parser middleware and receiving a request with a
        content type of "text/plain", this property is a string that
-       contains the body sent by the request. **/
+       contains the body sent by the request. */
   let bodyText: t => option(string);
 
-  /*** When using the urlencoded body-parser middleware and receiving a request
+  /** When using the urlencoded body-parser middleware and receiving a request
        with a content type of "application/x-www-form-urlencoded", this property
-        is a Js.Dict.t string that contains the body sent by the request. **/
+        is a Js.Dict.t string that contains the body sent by the request. */
   let bodyURLEncoded: t => option(Js.Dict.t(string));
 
-  /*** When using cookie-parser middleware, this property is an object
+  /** When using cookie-parser middleware, this property is an object
        that contains cookies sent by the request. If the request contains
        no cookies, it defaults to {}.*/
   let cookies: t => option(Js.Dict.t(Js.Json.t));
 
-  /*** When using cookie-parser middleware, this property contains signed cookies
+  /** When using cookie-parser middleware, this property contains signed cookies
        sent by the request, unsigned and ready for use. Signed cookies reside in
        a different object to show developer intent; otherwise, a malicious attack
        could be placed on req.cookie values (which are easy to spoof).
        Note that signing a cookie does not make it “hidden” or encrypted;
        but simply prevents tampering (because the secret used to
-       sign is private). **/
+       sign is private). */
   let signedCookies: t => option(Js.Dict.t(Js.Json.t));
 
-  /*** [hostname request] Contains the hostname derived from the Host
-       HTTP header.*/
+  /** [hostname request] Contains the hostname derived from the Host
+       HTTP header. */
   let hostname: t => string;
 
-  /*** [ip request] Contains the remote IP address of the request.*/
+  /** [ip request] Contains the remote IP address of the request. */
   let ip: t => string;
 
-  /*** [fresh request] returns [true] whether the request is "fresh" */
+  /** [fresh request] returns [true] whether the request is "fresh" */
   let fresh: t => bool;
 
-  /*** [stale request] returns [true] whether the request is "stale"*/
+  /** [stale request] returns [true] whether the request is "stale" */
   let stale: t => bool;
 
-  /*** [method_ request] return a string corresponding to the HTTP
+  /** [method_ request] return a string corresponding to the HTTP
        method of the request: GET, POST, PUT, and so on */
   let methodRaw: t => string;
   type httpMethod =
@@ -93,44 +93,44 @@ module Request: {
     | Connect
     | Patch;
 
-  /*** [method_ request] return a variant corresponding to the HTTP
+  /** [method_ request] return a variant corresponding to the HTTP
        method of the request: Get, Post, Put, and so on */
   let httpMethod: t => httpMethod;
 
-  /*** [originalUrl request] returns the original url. See
+  /** [originalUrl request] returns the original url. See
        https://expressjs.com/en/4x/api.html#req.originalUrl */
   let originalUrl: t => string;
 
-  /*** [path request] returns the path part of the request URL.*/
+  /** [path request] returns the path part of the request URL. */
   let path: t => string;
   type protocol =
     | Http
     | Https;
 
-  /*** [protocol request] returns the request protocol string: either http
+  /** [protocol request] returns the request protocol string: either http
        or (for TLS requests) https. */
   let protocol: t => protocol;
 
-  /*** [secure request] returns [true] if a TLS connection is established */
+  /** [secure request] returns [true] if a TLS connection is established */
   let secure: t => bool;
 
-  /*** [query request] returns an object containing a property for each
+  /** [query request] returns an object containing a property for each
        query string parameter in the route. If there is no query string,
        it returns the empty object, {} */
   let query: t => Js.Dict.t(Js.Json.t);
 
-  /*** [acceptsRaw accepts types] checks if the specified content types
+  /** [acceptsRaw accepts types] checks if the specified content types
        are acceptable, based on the request's Accept HTTP header field.
        The method returns the best match, or if none of the specified
        content types is acceptable, returns [false] */
   let accepts: (array(string), t) => option(string);
   let acceptsCharsets: (array(string), t) => option(string);
 
-  /*** [get return field] returns the specified HTTP request header
+  /** [get return field] returns the specified HTTP request header
        field (case-insensitive match) */
   let get: (string, t) => option(string);
 
-  /*** [xhr request] returns [true] if the request’s X-Requested-With
+  /** [xhr request] returns [true] if the request’s X-Requested-With
        header field is "XMLHttpRequest", indicating that the request was
        issued by a client library such as jQuery */
   let xhr: t => bool;
@@ -225,7 +225,7 @@ module Response: {
     ) =>
     t;
 
-  /***
+  /**
    Web browsers and other compliant clients will only clear the cookie if the given options is identical to those given to res.cookie(), excluding expires and maxAge.
     */
   let clearCookie:
@@ -251,15 +251,15 @@ module Next: {
   type content;
   type t = (Js.undefined(content), Response.t) => complete;
 
-  /*** value to use as [next] callback argument to invoke the next
+  /** value to use as [next] callback argument to invoke the next
        middleware */
   let middleware: Js.undefined(content);
 
-  /*** value to use as [next] callback argument to skip middleware
-       processing for the current route.*/
+  /** value to use as [next] callback argument to skip middleware
+       processing for the current route. */
   let route: Js.undefined(content);
 
-  /*** [error e] returns the argument for [next] callback to be propagate
+  /** [error e] returns the argument for [next] callback to be propagate
        error [e] through the chain of middleware. */
   let error: Error.t => Js.undefined(content);
 };
@@ -383,7 +383,7 @@ module App: {
 };
 
 
-/*** [express ()] creates an instance of the App class.
+/** [express ()] creates an instance of the App class.
      Alias for [App.make ()] */
 let express: unit => App.t;
 
@@ -404,9 +404,9 @@ module Static: {
   let setHeaders: (options, (Request.t, string, stat) => unit) => unit;
   type t;
 
-  /*** [make directory] creates a static middleware for [directory] */
+  /** [make directory] creates a static middleware for [directory] */
   let make: (string, options) => t;
 
-  /*** [asMiddleware static] casts [static] to a Middleware type */
+  /** [asMiddleware static] casts [static] to a Middleware type */
   let asMiddleware: t => Middleware.t;
 };


### PR DESCRIPTION
The standard _doc comment_ format in Ocaml / ReasonML is opening with two asterisks (`*`), and ending with a single asterisk.

When it is opening with three `*`, my VSCode plugin (_reason-vscode_) does not recognize this as _doc comment_:
![Skjermbilde 2019-07-05 kl  16 34 05](https://user-images.githubusercontent.com/2505178/60729727-b502de00-9f43-11e9-969c-8b21815d7c76.png)

But when removing one of them it works:
![Skjermbilde 2019-07-05 kl  16 33 18](https://user-images.githubusercontent.com/2505178/60729751-be8c4600-9f43-11e9-9792-5e3e1c847378.png)

It should end with a single asterisk, if it is more than one the remainings will be printed as part of the _doc comment_:
![Skjermbilde 2019-07-05 kl  16 34 45](https://user-images.githubusercontent.com/2505178/60729794-d4017000-9f43-11e9-93e0-c9145a33ade2.png)
