### PR TITLE
Move body-parser to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "Express bindings in Reason",
   "main": "index.js",
   "dependencies": {
+    "body-parser": "^1.18.3",
     "express": "^4.16.3"
   },
   "devDependencies": {
     "@glennsl/bs-json": "^3.0.0",
-    "body-parser": "^1.18.3",
     "bs-platform": "^5.0.2",
     "husky": "^1.0.0-rc.13"
   },


### PR DESCRIPTION
`bs-express` requires `body-parser` which is a dependency of `express`. For projects based on `npm` or `yarn`, this works out in practice since these package managers flatten the dependency graph and allow packages to see their transitive dependencies. But we want to use `bs-express` with [pnpm](https://pnpm.js.org/) which only exposes direct dependencies, so we need to declare the dependency in `dependencies` instead of in `devDependencies`.