### PR TITLE
fix dead link to interface file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install --save bs-express
 
 ---
 
-Right now the library is somewhat underdocumented, so please view the interface file [`Express.rei`](./src/Express.rei) or the [example folder](./example/) to see library usage.
+Right now the library is somewhat underdocumented, so please view the interface file [`Express.resi`](./src/Express.resi) or the [example folder](./example/) to see library usage.
 
 ---
 


### PR DESCRIPTION
I discovered a dead link in the documentation. Since there was an obvious fix, I thought opening the PR would be easier than opening an issue.