### PR TITLE
Fix a bug in the static middleware setHeaders type signature

### DIFF
--- a/src/Express.res
+++ b/src/Express.res
@@ -583,7 +583,7 @@ module Static = {
   @bs.set external lastModified: (options, bool) => unit = "lastModified"
   @bs.set external maxAge: (options, int) => unit = "maxAge"
   @bs.set external redirect: (options, bool) => unit = "redirect"
-  @bs.set external setHeaders: (options, (Request.t, string, stat) => unit) => unit = "setHeaders"
+  @bs.set external setHeaders: (options, (Response.t, string, stat) => unit) => unit = "setHeaders"
 
   @bs.module("express") external make: (string, options) => t = "static"
 

--- a/src/Express.resi
+++ b/src/Express.resi
@@ -461,7 +461,7 @@ module Static: {
   @bs.set external lastModified: (options, bool) => unit = "lastModified"
   @bs.set external maxAge: (options, int) => unit = "maxAge"
   @bs.set external redirect: (options, bool) => unit = "redirect"
-  @bs.set external setHeaders: (options, (Request.t, string, stat) => unit) => unit = "setHeaders"
+  @bs.set external setHeaders: (options, (Response.t, string, stat) => unit) => unit = "setHeaders"
 
   @ocaml.doc("[make directory] creates a static middleware for [directory]") @bs.module("express")
   external make: (string, options) => t = "static"


### PR DESCRIPTION
Today I was trying to customise the `setHeaders` option of the Express static middleware and noticed that the type signature in bs-express expects `Request.t`, but it should be `Response.t`. See [the docs](https://expressjs.com/en/4x/api.html#setHeaders).

I couldn't get the tests working locally. I realize this project is not very actively maintained but if anyone could assist with that I'd be happy to put the effort in.

Thanks.